### PR TITLE
perf(api): increase batch size for database upserts

### DIFF
--- a/src/app/api/upload-stats/route.ts
+++ b/src/app/api/upload-stats/route.ts
@@ -121,8 +121,8 @@ export async function POST(request: NextRequest) {
     const affectedBuckets = new Set<string>();
 
     // Upsert all messages (insert new, update existing)
-    // Process in batches to avoid overwhelming the database connection pool
-    const BATCH_SIZE = 10;
+    // Process in batches for controlled concurrency
+    const BATCH_SIZE = 50;
     for (let i = 0; i < body.length; i += BATCH_SIZE) {
       const batch = body.slice(i, i + BATCH_SIZE);
       


### PR DESCRIPTION
Change batch size from 10 to 50.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized message statistics processing performance by increasing batch processing efficiency for improved concurrency and throughput.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->