### PR TITLE
perf(api): batch upserts in single transaction for upload-stats

### DIFF
--- a/src/lib/timing.ts
+++ b/src/lib/timing.ts
@@ -1,0 +1,9 @@
+// Small helper for optional performance timing logs.
+// Enabled when SPLITRAIL_UPLOAD_TIMING=1.
+export function timingEnabled() {
+  return process.env.SPLITRAIL_UPLOAD_TIMING === "1";
+}
+
+export function nowMs() {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}


### PR DESCRIPTION
Replace per-message batch processing with a single database transaction containing all upserts. This reduces connection round trips and per-message transaction overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation and error handling for upload requests with clearer error messages.

* **Performance**
  * Optimized upload processing with improved database transaction handling.
  * Added optional performance timing instrumentation for upload operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->