### PR TITLE
Add `created_at` to messages

### DIFF
--- a/prisma/migrations/20260113000000_add_message_stats_created_at/migration.sql
+++ b/prisma/migrations/20260113000000_add_message_stats_created_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "message_stats" ADD COLUMN "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,8 @@ model MessageStats {
   todoWrites            BigInt    @default(0)
   todoReads             BigInt    @default(0)
   
+  createdAt             DateTime?  @default(now())
+  
   user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   
   @@index([userId, date])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added creation timestamps to message statistics for improved record tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->