### PR TITLE
fix: replace O(N×4) recalculation loop with single-SQL-per-period approach

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,6 +87,9 @@ model MessageStats {
   @@index([userId, date])
   @@index([date])
   @@index([application, date])
+  // Covers the conversation-counting query in stats recalculation which filters
+  // by (userId, application) and groups by conversationHash with a MIN(date).
+  @@index([userId, application, conversationHash, date])
   @@map("message_stats")
 }
 

--- a/src/app/api/upload-stats/route.ts
+++ b/src/app/api/upload-stats/route.ts
@@ -296,27 +296,39 @@ export async function POST(request: NextRequest) {
     // Perform bulk upsert and recalculation in a single atomic transaction to ensure
     // that affectedPeriods matches the exact rows being committed.
     // We chunk the upsert to avoid oversized SQL while keeping everything in one transaction.
-    await db.$transaction(async (tx) => {
-      const BULK_UPSERT_BATCH_SIZE = 500;
-      for (let i = 0; i < newMessagesForDb.length; i += BULK_UPSERT_BATCH_SIZE) {
-        const batch = newMessagesForDb.slice(i, i + BULK_UPSERT_BATCH_SIZE);
-        await tx.$executeRaw(bulkUpsertMessageStatsSql(batch));
+    await db.$transaction(
+      async (tx) => {
+        const BULK_UPSERT_BATCH_SIZE = 500;
+        for (
+          let i = 0;
+          i < newMessagesForDb.length;
+          i += BULK_UPSERT_BATCH_SIZE
+        ) {
+          const batch = newMessagesForDb.slice(i, i + BULK_UPSERT_BATCH_SIZE);
+          await tx.$executeRaw(bulkUpsertMessageStatsSql(batch));
+        }
+
+        mark("upserted");
+
+        // Recalculate aggregate stats for every affected period bucket using a
+        // single efficient SQL statement per period type (5 total) instead of the
+        // old approach of 4 separate queries × N buckets.  This reduces thousands
+        // of sequential DB round-trips to at most 5, eliminating the timeout.
+        await recalculateUserStats(
+          user.id,
+          Array.from(affectedApplications),
+          affectedPeriods,
+          tx, // use transaction client
+          timezone
+        );
+      },
+      {
+        // Prisma's default interactive transaction timeout is 5s — far too short
+        // for large uploads.  Allow up to 2 minutes for the combined bulk upsert
+        // + stats recalculation.
+        timeout: 120_000,
       }
-
-      mark("upserted");
-
-      // Recalculate aggregate stats for every affected period bucket using a
-      // single efficient SQL statement per period type (5 total) instead of the
-      // old approach of 4 separate queries × N buckets.  This reduces thousands
-      // of sequential DB round-trips to at most 5, eliminating the timeout.
-      await recalculateUserStats(
-        user.id,
-        Array.from(affectedApplications),
-        affectedPeriods,
-        tx, // use transaction client
-        timezone
-      );
-    });
+    );
 
     // Emit timing breakdown once per request
     mark("recalculated");

--- a/src/app/api/upload-stats/route.ts
+++ b/src/app/api/upload-stats/route.ts
@@ -293,27 +293,30 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // Bulk upsert via Postgres INSERT .. ON CONFLICT to avoid per-row Prisma upserts.
-    // Neon/Postgres handles this efficiently; we chunk to avoid oversized SQL.
-    const BULK_UPSERT_BATCH_SIZE = 500;
-    for (let i = 0; i < newMessagesForDb.length; i += BULK_UPSERT_BATCH_SIZE) {
-      const batch = newMessagesForDb.slice(i, i + BULK_UPSERT_BATCH_SIZE);
-      await db.$executeRaw(bulkUpsertMessageStatsSql(batch));
-    }
+    // Perform bulk upsert and recalculation in a single atomic transaction to ensure
+    // that affectedPeriods matches the exact rows being committed.
+    // We chunk the upsert to avoid oversized SQL while keeping everything in one transaction.
+    await db.$transaction(async (tx) => {
+      const BULK_UPSERT_BATCH_SIZE = 500;
+      for (let i = 0; i < newMessagesForDb.length; i += BULK_UPSERT_BATCH_SIZE) {
+        const batch = newMessagesForDb.slice(i, i + BULK_UPSERT_BATCH_SIZE);
+        await tx.$executeRaw(bulkUpsertMessageStatsSql(batch));
+      }
 
-    mark("upserted");
+      mark("upserted");
 
-    // Recalculate aggregate stats for every affected period bucket using a
-    // single efficient SQL statement per period type (5 total) instead of the
-    // old approach of 4 separate queries × N buckets.  This reduces thousands
-    // of sequential DB round-trips to at most 5, eliminating the timeout.
-    await recalculateUserStats(
-      user.id,
-      Array.from(affectedApplications),
-      affectedPeriods,
-      undefined, // use default db client
-      timezone
-    );
+      // Recalculate aggregate stats for every affected period bucket using a
+      // single efficient SQL statement per period type (5 total) instead of the
+      // old approach of 4 separate queries × N buckets.  This reduces thousands
+      // of sequential DB round-trips to at most 5, eliminating the timeout.
+      await recalculateUserStats(
+        user.id,
+        Array.from(affectedApplications),
+        affectedPeriods,
+        tx, // use transaction client
+        timezone
+      );
+    });
 
     // Emit timing breakdown once per request
     mark("recalculated");

--- a/src/app/api/upload-stats/route.ts
+++ b/src/app/api/upload-stats/route.ts
@@ -1,11 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { type ConversationMessage, Periods } from "@/types";
-import {
-  getPeriodEndForDateInTimezone,
-  getPeriodQueryEndForDateInTimezone,
-  getPeriodStartForDateInTimezone,
-} from "@/lib/dateUtils";
+import { getPeriodStartForDateInTimezone } from "@/lib/dateUtils";
 import { unsupportedMethod } from "@/lib/routeUtils";
 import { Prisma } from "@prisma/client";
 import { nowMs, timingEnabled } from "@/lib/timing";
@@ -13,6 +9,14 @@ import {
   bulkUpsertMessageStatsSql,
   type MessageStatsUpsertRow,
 } from "@/lib/message-stats-bulk-upsert";
+import {
+  type AffectedPeriods,
+  addUniqueDate,
+  recalculateUserStats,
+} from "@/lib/stats-recalculation";
+
+// Allow up to 5 minutes for large uploads with many affected period buckets.
+export const maxDuration = 300;
 
 /**
  * Handles uploading conversation messages, upserting per-message stats, and recalculating per-period user aggregates.
@@ -114,17 +118,13 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // Track affected period buckets for recalculation
-    // Key format: ${period}|${application}|${periodStart.toISOString()}
-    const affectedBuckets = new Set<string>();
-
     // Build all upsert inputs synchronously (no DB I/O yet)
     const messagesForDb: MessageStatsUpsertRow[] = dedupedBody.map(
       (message) => {
         const { stats, date, ...rest } = message;
         const messageDate = new Date(date);
 
-        const dbMessage: MessageStatsUpsertRow = {
+        return {
           globalHash: message.globalHash,
           userId: user.id,
           application: message.application,
@@ -195,18 +195,6 @@ export async function POST(request: NextRequest) {
               ? (rest.fileTypes as Prisma.InputJsonValue)
               : null) ?? null,
         };
-
-        for (const period of Periods) {
-          const periodStart = getPeriodStartForDateInTimezone(
-            period,
-            messageDate,
-            timezone
-          );
-          const key = `${period}|${message.application}|${periodStart.toISOString()}`;
-          affectedBuckets.add(key);
-        }
-
-        return dbMessage;
       }
     );
 
@@ -220,6 +208,42 @@ export async function POST(request: NextRequest) {
       select: { globalHash: true },
     });
     const duplicateCount = existingMessages.length;
+    const existingHashSet = new Set(
+      existingMessages.map((message) => message.globalHash)
+    );
+    const newMessagesForDb = messagesForDb.filter(
+      (message) => !existingHashSet.has(message.globalHash as string)
+    );
+
+    // Compute affected period buckets for recalculation based only on genuinely
+    // new messages.  We build an AffectedPeriods structure (unique periodStart
+    // dates per period type) plus a set of affected applications so that the
+    // efficient single-SQL-per-period recalculation function can be used.
+    const affectedPeriods: AffectedPeriods = {
+      hourly: [],
+      daily: [],
+      weekly: [],
+      monthly: [],
+      yearly: [],
+    };
+    const affectedApplications = new Set<string>();
+    for (const message of newMessagesForDb) {
+      affectedApplications.add(message.application as string);
+      for (const period of Periods) {
+        const periodStart = getPeriodStartForDateInTimezone(
+          period,
+          message.date as Date,
+          timezone
+        );
+        addUniqueDate(affectedPeriods[period], periodStart);
+      }
+    }
+    const affectedBucketCount =
+      affectedPeriods.hourly.length +
+      affectedPeriods.daily.length +
+      affectedPeriods.weekly.length +
+      affectedPeriods.monthly.length +
+      affectedPeriods.yearly.length;
 
     if (duplicateCount > 0) {
       console.warn("upload-stats: duplicate messages detected", {
@@ -236,7 +260,7 @@ export async function POST(request: NextRequest) {
 
     mark("duplicateCheck");
 
-    const newMessageCount = messagesForDb.length - duplicateCount;
+    const newMessageCount = newMessagesForDb.length;
 
     // If this upload is entirely duplicates, there is nothing to upsert or recalculate.
     // Returning early avoids re-running expensive bucket aggregations for no-op uploads.
@@ -272,195 +296,24 @@ export async function POST(request: NextRequest) {
     // Bulk upsert via Postgres INSERT .. ON CONFLICT to avoid per-row Prisma upserts.
     // Neon/Postgres handles this efficiently; we chunk to avoid oversized SQL.
     const BULK_UPSERT_BATCH_SIZE = 500;
-    for (let i = 0; i < messagesForDb.length; i += BULK_UPSERT_BATCH_SIZE) {
-      const batch = messagesForDb.slice(i, i + BULK_UPSERT_BATCH_SIZE);
+    for (let i = 0; i < newMessagesForDb.length; i += BULK_UPSERT_BATCH_SIZE) {
+      const batch = newMessagesForDb.slice(i, i + BULK_UPSERT_BATCH_SIZE);
       await db.$executeRaw(bulkUpsertMessageStatsSql(batch));
     }
 
     mark("upserted");
 
-    // Recalculate stats for each affected bucket by summing all messages
-    const now = new Date();
-
-    for (const bucketKey of affectedBuckets) {
-      // Parse bucket key safely - application name could theoretically contain "|"
-      // Key format: ${period}|${application}|${periodStart.toISOString()}
-      // Period is always first, ISO date is always last, application is in between
-      const firstPipe = bucketKey.indexOf("|");
-      const lastPipe = bucketKey.lastIndexOf("|");
-      const period = bucketKey.slice(0, firstPipe);
-      const application = bucketKey.slice(firstPipe + 1, lastPipe);
-      const periodStart = new Date(bucketKey.slice(lastPipe + 1));
-      const typedPeriod = period as (typeof Periods)[number];
-      const periodEnd = getPeriodEndForDateInTimezone(
-        typedPeriod,
-        periodStart,
-        timezone
-      );
-      const periodQueryEnd = getPeriodQueryEndForDateInTimezone(
-        typedPeriod,
-        periodStart,
-        timezone
-      );
-
-      // Aggregate all messages in this bucket
-      const aggregation = await db.messageStats.aggregate({
-        where: {
-          userId: user.id,
-          application,
-          date: {
-            gte: periodStart,
-            lt: periodQueryEnd,
-          },
-        },
-        _sum: {
-          inputTokens: true,
-          outputTokens: true,
-          cacheCreationTokens: true,
-          cacheReadTokens: true,
-          cachedTokens: true,
-          reasoningTokens: true,
-          cost: true,
-          toolCalls: true,
-          filesRead: true,
-          filesAdded: true,
-          filesEdited: true,
-          filesDeleted: true,
-          linesRead: true,
-          linesAdded: true,
-          linesEdited: true,
-          linesDeleted: true,
-          bytesRead: true,
-          bytesAdded: true,
-          bytesEdited: true,
-          bytesDeleted: true,
-          codeLines: true,
-          docsLines: true,
-          dataLines: true,
-          mediaLines: true,
-          configLines: true,
-          otherLines: true,
-          terminalCommands: true,
-          fileSearches: true,
-          fileContentSearches: true,
-          todosCreated: true,
-          todosCompleted: true,
-          todosInProgress: true,
-          todoWrites: true,
-          todoReads: true,
-        },
-      });
-
-      // Count messages by role
-      const messageCounts = await db.messageStats.groupBy({
-        by: ["role"],
-        where: {
-          userId: user.id,
-          application,
-          date: {
-            gte: periodStart,
-            lt: periodQueryEnd,
-          },
-        },
-        _count: true,
-      });
-
-      const assistantCount =
-        messageCounts.find((m) => m.role === "assistant")?._count ?? 0;
-      const userCount =
-        messageCounts.find((m) => m.role === "user")?._count ?? 0;
-
-      // Conversation starts + model list for this bucket (used by dashboard cache reads)
-      const [conversationAndModelData] = await db.$queryRaw<
-        Array<{ conversations: bigint; models: string[] | null }>
-      >`
-        SELECT
-          COUNT(DISTINCT m."conversationHash") FILTER (
-            WHERE NOT EXISTS (
-              SELECT 1
-              FROM message_stats prev
-              WHERE prev."userId" = ${user.id}
-                AND prev.application = ${application}
-                AND prev."conversationHash" = m."conversationHash"
-                AND prev.date < ${periodStart}
-            )
-          )::bigint AS conversations,
-          ARRAY_AGG(DISTINCT m.model) FILTER (WHERE m.model IS NOT NULL) AS models
-        FROM message_stats m
-        WHERE m."userId" = ${user.id}
-          AND m.application = ${application}
-          AND m.date >= ${periodStart}
-          AND m.date < ${periodQueryEnd}
-      `;
-
-      // Build the stats record from aggregation
-      const statsData: Prisma.UserStatsUncheckedCreateInput = {
-        userId: user.id,
-        application,
-        period,
-        periodStart,
-        periodEnd,
-        assistantMessages: BigInt(assistantCount),
-        userMessages: BigInt(userCount),
-        inputTokens: aggregation._sum.inputTokens ?? BigInt(0),
-        outputTokens: aggregation._sum.outputTokens ?? BigInt(0),
-        cacheCreationTokens: aggregation._sum.cacheCreationTokens ?? BigInt(0),
-        cacheReadTokens: aggregation._sum.cacheReadTokens ?? BigInt(0),
-        cachedTokens: aggregation._sum.cachedTokens ?? BigInt(0),
-        reasoningTokens: aggregation._sum.reasoningTokens ?? BigInt(0),
-        cost: aggregation._sum.cost ?? 0,
-        toolCalls: aggregation._sum.toolCalls ?? BigInt(0),
-        filesRead: aggregation._sum.filesRead ?? BigInt(0),
-        filesAdded: aggregation._sum.filesAdded ?? BigInt(0),
-        filesEdited: aggregation._sum.filesEdited ?? BigInt(0),
-        filesDeleted: aggregation._sum.filesDeleted ?? BigInt(0),
-        linesRead: aggregation._sum.linesRead ?? BigInt(0),
-        linesAdded: aggregation._sum.linesAdded ?? BigInt(0),
-        linesEdited: aggregation._sum.linesEdited ?? BigInt(0),
-        linesDeleted: aggregation._sum.linesDeleted ?? BigInt(0),
-        bytesRead: aggregation._sum.bytesRead ?? BigInt(0),
-        bytesAdded: aggregation._sum.bytesAdded ?? BigInt(0),
-        bytesEdited: aggregation._sum.bytesEdited ?? BigInt(0),
-        bytesDeleted: aggregation._sum.bytesDeleted ?? BigInt(0),
-        codeLines: aggregation._sum.codeLines ?? BigInt(0),
-        docsLines: aggregation._sum.docsLines ?? BigInt(0),
-        dataLines: aggregation._sum.dataLines ?? BigInt(0),
-        mediaLines: aggregation._sum.mediaLines ?? BigInt(0),
-        configLines: aggregation._sum.configLines ?? BigInt(0),
-        otherLines: aggregation._sum.otherLines ?? BigInt(0),
-        terminalCommands: aggregation._sum.terminalCommands ?? BigInt(0),
-        fileSearches: aggregation._sum.fileSearches ?? BigInt(0),
-        fileContentSearches: aggregation._sum.fileContentSearches ?? BigInt(0),
-        todosCreated: aggregation._sum.todosCreated ?? BigInt(0),
-        todosCompleted: aggregation._sum.todosCompleted ?? BigInt(0),
-        todosInProgress: aggregation._sum.todosInProgress ?? BigInt(0),
-        todoWrites: aggregation._sum.todoWrites ?? BigInt(0),
-        todoReads: aggregation._sum.todoReads ?? BigInt(0),
-        conversations: conversationAndModelData?.conversations ?? BigInt(0),
-        models: conversationAndModelData?.models ?? [],
-        createdAt: now,
-        updatedAt: now,
-      };
-
-      // Upsert the stats record (replace with recalculated values)
-      await db.userStats.upsert({
-        where: {
-          userId_period_application_periodStart: {
-            userId: user.id,
-            period,
-            application,
-            periodStart,
-          },
-        },
-        create: statsData,
-        update: {
-          ...statsData,
-          // Preserve original createdAt on update (undefined is omitted by Prisma 5.x)
-          // Note: Upgrade to Prisma.skip when migrating to Prisma 6+
-          createdAt: undefined,
-        },
-      });
-    }
+    // Recalculate aggregate stats for every affected period bucket using a
+    // single efficient SQL statement per period type (5 total) instead of the
+    // old approach of 4 separate queries × N buckets.  This reduces thousands
+    // of sequential DB round-trips to at most 5, eliminating the timeout.
+    await recalculateUserStats(
+      user.id,
+      Array.from(affectedApplications),
+      affectedPeriods,
+      undefined, // use default db client
+      timezone
+    );
 
     // Emit timing breakdown once per request
     mark("recalculated");
@@ -484,7 +337,7 @@ export async function POST(request: NextRequest) {
       console.info("upload-stats timings", {
         messages: dedupedBody.length,
         duplicates: duplicateCount,
-        affectedBuckets: affectedBuckets.size,
+        affectedBuckets: affectedBucketCount,
         preparedMs,
         duplicateCheckMs,
         upsertedMs,

--- a/src/lib/stats-recalculation.ts
+++ b/src/lib/stats-recalculation.ts
@@ -250,11 +250,19 @@ export async function deleteAffectedUserStats(
   });
 }
 
-function getPeriodEndExpression(period: keyof AffectedPeriods): Prisma.Sql {
+function getPeriodEndExpression(
+  period: keyof AffectedPeriods,
+  timezone: string | null
+): Prisma.Sql {
   switch (period) {
     case "hourly":
       return Prisma.sql`a.period_start + INTERVAL '59 minutes 59.999 seconds'`;
     case "daily":
+      if (timezone) {
+        // Timezone-aware daily period end: truncate period_start to day in timezone,
+        // add one day minus one millisecond, then convert back to timezone
+        return Prisma.sql`((date_trunc('day', a.period_start AT TIME ZONE ${timezone}) + INTERVAL '1 day' - INTERVAL '1 millisecond') AT TIME ZONE ${timezone})`;
+      }
       return Prisma.sql`a.period_start + INTERVAL '23 hours 59 minutes 59.999 seconds'`;
     case "weekly":
       return Prisma.sql`a.period_start + INTERVAL '6 days 23 hours 59 minutes 59.999 seconds'`;
@@ -270,7 +278,8 @@ function getPeriodEndExpression(period: keyof AffectedPeriods): Prisma.Sql {
  *
  * For daily periods when a timezone is provided, uses Postgres timezone-aware
  * truncation so that day boundaries align with the user's local midnight rather
- * than UTC midnight.  All other period types use plain UTC date_trunc.
+ * than UTC midnight.  All other period types use UTC date_trunc pinned to UTC
+ * to ensure deterministic truncation regardless of session timezone.
  */
 function periodTruncSql(
   column: Prisma.Sql,
@@ -282,7 +291,8 @@ function periodTruncSql(
     // date AT TIME ZONE tz → local timestamp; truncate to day; AT TIME ZONE tz → back to timestamptz
     return Prisma.sql`(date_trunc('day', ${column} AT TIME ZONE ${timezone})) AT TIME ZONE ${timezone}`;
   }
-  return Prisma.sql`date_trunc(${truncUnit}, ${column})`;
+  // Pin non-daily truncation to UTC by applying the same AT TIME ZONE round-trip
+  return Prisma.sql`(date_trunc(${truncUnit}, ${column} AT TIME ZONE 'UTC')) AT TIME ZONE 'UTC'`;
 }
 
 export async function recalculateUserStats(
@@ -514,7 +524,7 @@ export async function recalculateUserStats(
         a.application,
         ${config.period},
         a.period_start,
-        ${getPeriodEndExpression(config.period)},
+        ${getPeriodEndExpression(config.period, tz)},
         a.tool_calls,
         a.assistant_messages,
         a.user_messages,

--- a/src/lib/stats-recalculation.ts
+++ b/src/lib/stats-recalculation.ts
@@ -33,7 +33,7 @@ function getWeekStart(date: Date): Date {
   return getPeriodStartForDate("weekly", date);
 }
 
-function addUniqueDate(target: Date[], value: Date) {
+export function addUniqueDate(target: Date[], value: Date) {
   if (!target.some((date) => date.getTime() === value.getTime())) {
     target.push(value);
   }
@@ -265,11 +265,32 @@ function getPeriodEndExpression(period: keyof AffectedPeriods): Prisma.Sql {
   }
 }
 
+/**
+ * Build the SQL expression for truncating a timestamp column to a period boundary.
+ *
+ * For daily periods when a timezone is provided, uses Postgres timezone-aware
+ * truncation so that day boundaries align with the user's local midnight rather
+ * than UTC midnight.  All other period types use plain UTC date_trunc.
+ */
+function periodTruncSql(
+  column: Prisma.Sql,
+  truncUnit: string,
+  period: string,
+  timezone: string | null
+): Prisma.Sql {
+  if (period === "daily" && timezone) {
+    // date AT TIME ZONE tz → local timestamp; truncate to day; AT TIME ZONE tz → back to timestamptz
+    return Prisma.sql`(date_trunc('day', ${column} AT TIME ZONE ${timezone})) AT TIME ZONE ${timezone}`;
+  }
+  return Prisma.sql`date_trunc(${truncUnit}, ${column})`;
+}
+
 export async function recalculateUserStats(
   userId: string,
   applications: string[],
   affectedPeriods: AffectedPeriods,
-  client?: StatsRecalculationClient
+  client?: StatsRecalculationClient,
+  timezone?: string | null
 ) {
   const prisma: StatsRecalculationClient =
     client ?? (await import("@/lib/db")).db;
@@ -307,8 +328,26 @@ export async function recalculateUserStats(
     },
   ];
 
+  const tz = timezone ?? null;
+
   for (const config of periodConfigs) {
     if (config.periodStarts.length === 0) continue;
+
+    // Build timezone-aware date truncation expressions for this period type.
+    // For daily periods with a timezone, day boundaries align with the user's
+    // local midnight instead of UTC midnight.
+    const truncDate = periodTruncSql(
+      Prisma.raw("date"),
+      config.truncUnit,
+      config.period,
+      tz
+    );
+    const truncFirstMsg = periodTruncSql(
+      Prisma.raw("first_message_at"),
+      config.truncUnit,
+      config.period,
+      tz
+    );
 
     // Aggregate and upsert in a single statement so the caller's transaction
     // stays atomic without paying one round-trip per period/application row.
@@ -360,7 +399,7 @@ export async function recalculateUserStats(
       ),
       aggregated_stats AS (
         SELECT
-          date_trunc(${config.truncUnit}, date) AS period_start,
+          ${truncDate} AS period_start,
           application,
           COALESCE(SUM("toolCalls"), 0)::bigint AS tool_calls,
           COALESCE(SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END), 0)::bigint AS assistant_messages,
@@ -400,7 +439,7 @@ export async function recalculateUserStats(
           COALESCE(SUM("todoReads"), 0)::bigint AS todo_reads,
           ARRAY_AGG(DISTINCT model) FILTER (WHERE model IS NOT NULL) AS models
         FROM base
-        WHERE date_trunc(${config.truncUnit}, date) = ANY(${config.periodStarts})
+        WHERE ${truncDate} = ANY(${config.periodStarts})
         GROUP BY period_start, application
         HAVING COUNT(*) > 0
       ),
@@ -415,11 +454,11 @@ export async function recalculateUserStats(
       ),
       conversation_counts AS (
         SELECT
-          date_trunc(${config.truncUnit}, first_message_at) AS period_start,
+          ${truncFirstMsg} AS period_start,
           application,
           COUNT(*)::bigint AS conversations
         FROM conversation_starts
-        WHERE date_trunc(${config.truncUnit}, first_message_at) = ANY(${config.periodStarts})
+        WHERE ${truncFirstMsg} = ANY(${config.periodStarts})
         GROUP BY period_start, application
       )
       INSERT INTO user_stats (


### PR DESCRIPTION
The upload route was doing 4 separate DB queries per affected time-period bucket (aggregate, groupBy, raw conversation count, upsert) in a sequential loop.  For a 3K-message chunk spanning 60 days, this meant ~6,000 DB round-trips to Neon — far exceeding Vercel's function timeout.

Changes:
- Replace inline recalculation loop with recalculateUserStats() which uses a single CTE-based INSERT...SELECT...ON CONFLICT per period type (5 total)
- Add timezone support to recalculateUserStats() so daily period boundaries respect the user's local midnight (matching the upload route's existing timezone-aware behavior)
- Add maxDuration = 300 to the upload route for large uploads
- Add composite index on message_stats(userId, application, conversationHash, date) to speed up conversation counting queries

Net effect: ~6,000 sequential DB queries → 5 efficient bulk queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added a new index to speed common message-stat queries.
  * Consolidated writes and recalculation into transactional bulk operations for faster, more reliable processing.

* **Bug Fixes**
  * Improved duplicate message detection so only new messages are committed and reprocessed.

* **New Features**
  * Timezone-aware period handling for more accurate per-period statistics across regions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->