### PR TITLE
fix: correct AT TIME ZONE for timestamp without time zone in daily recalculation

### DIFF
--- a/src/lib/stats-recalculation.ts
+++ b/src/lib/stats-recalculation.ts
@@ -288,8 +288,13 @@ function periodTruncSql(
   timezone: string | null
 ): Prisma.Sql {
   if (period === "daily" && timezone) {
-    // date AT TIME ZONE tz → local timestamp; truncate to day; AT TIME ZONE tz → back to timestamptz
-    return Prisma.sql`(date_trunc('day', ${column} AT TIME ZONE ${timezone})) AT TIME ZONE ${timezone}`;
+    // The column is `timestamp without time zone` storing UTC values.  The first
+    // `AT TIME ZONE 'UTC'` interprets the bare timestamp as UTC (producing
+    // timestamptz).  The second `AT TIME ZONE tz` converts to local time
+    // (producing timestamp).  After truncating to day we reverse the conversion
+    // back to timestamptz so the result is comparable with the JS-computed
+    // period-start Date values.
+    return Prisma.sql`(date_trunc('day', ${column} AT TIME ZONE 'UTC' AT TIME ZONE ${timezone})) AT TIME ZONE ${timezone}`;
   }
   // Pin non-daily truncation to UTC by applying the same AT TIME ZONE round-trip
   return Prisma.sql`(date_trunc(${truncUnit}, ${column} AT TIME ZONE 'UTC')) AT TIME ZONE 'UTC'`;


### PR DESCRIPTION
The periodTruncSql function used `date AT TIME ZONE tz` directly on the message_stats.date column, which is `timestamp without time zone` storing UTC values.  For this column type, AT TIME ZONE *interprets* the value as local time (wrong) instead of *converting from* UTC to local time.  This produced period_start values offset by 2×UTC_offset (e.g. T18:00Z instead of T06:00Z for America/Boise), causing the WHERE period_start = ANY(periodStarts) filter to silently match nothing and insert zero daily user_stats rows.

Fix: add an intermediate `AT TIME ZONE 'UTC'` to first promote the bare timestamp to timestamptz (correctly interpreted as UTC), then convert to local time with `AT TIME ZONE tz`.

Hourly/weekly/monthly/yearly periods were unaffected because they already use `AT TIME ZONE 'UTC'` which is a no-op for UTC timestamps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily statistics calculation to properly handle timezone conversions, ensuring accurate conversation count aggregations across different timezones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->