### PR TITLE
Fix timezone-aware stats deletion

### DIFF
--- a/scripts/check-delete-date-bounds.ts
+++ b/scripts/check-delete-date-bounds.ts
@@ -1,0 +1,53 @@
+import { getDeleteDateBounds } from "../src/app/api/user/[userId]/stats/route";
+
+function assertEqual(actual: string, expected: string, label: string) {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${expected}, got ${actual}`);
+  }
+}
+
+const winter = getDeleteDateBounds(
+  "2026-01-15",
+  "2026-01-15",
+  "America/Boise"
+);
+assertEqual(
+  winter.startDateTime.toISOString(),
+  "2026-01-15T07:00:00.000Z",
+  "winter start"
+);
+assertEqual(
+  winter.endDateTime.toISOString(),
+  "2026-01-16T06:59:59.999Z",
+  "winter end"
+);
+
+const summer = getDeleteDateBounds(
+  "2026-05-30",
+  "2026-05-30",
+  "America/Boise"
+);
+assertEqual(
+  summer.startDateTime.toISOString(),
+  "2026-05-30T06:00:00.000Z",
+  "summer start"
+);
+assertEqual(
+  summer.endDateTime.toISOString(),
+  "2026-05-31T05:59:59.999Z",
+  "summer end"
+);
+
+const utcFallback = getDeleteDateBounds("2026-01-15", "2026-01-15", null);
+assertEqual(
+  utcFallback.startDateTime.toISOString(),
+  "2026-01-15T00:00:00.000Z",
+  "UTC fallback start"
+);
+assertEqual(
+  utcFallback.endDateTime.toISOString(),
+  "2026-01-15T23:59:59.999Z",
+  "UTC fallback end"
+);
+
+console.log("delete date bounds checks passed");

--- a/src/app/api/user/[userId]/stats/route.ts
+++ b/src/app/api/user/[userId]/stats/route.ts
@@ -1,3 +1,4 @@
+import { TZDate } from "@date-fns/tz";
 import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { auth } from "@/auth";
@@ -11,6 +12,7 @@ import {
   mergeAffectedPeriods,
   recalculateUserStats,
 } from "@/lib/stats-recalculation";
+
 import {
   createEmptyTotalsAccumulator,
   type DailyStatsRow,
@@ -24,6 +26,57 @@ import { type StatsCollection } from "@/app/_stats/types";
 
 function parseDailyStatsDay(day: DailyStatsRow["day"]): Date {
   return day instanceof Date ? day : new Date(day);
+}
+
+function parseLocalDateParts(date: string): {
+  year: number;
+  monthIndex: number;
+  day: number;
+} {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) {
+    return { year: NaN, monthIndex: NaN, day: NaN };
+  }
+
+  return {
+    year: Number(match[1]),
+    monthIndex: Number(match[2]) - 1,
+    day: Number(match[3]),
+  };
+}
+
+function localDateParamToUtc(date: string, timezone: string): Date {
+  const { year, monthIndex, day } = parseLocalDateParts(date);
+  return new Date(new TZDate(year, monthIndex, day, timezone).getTime());
+}
+
+export function getDeleteDateBounds(
+  startDate: string,
+  endDate: string,
+  timezone: string | null
+): { startDateTime: Date; endDateTime: Date } {
+  if (timezone) {
+    const startDateTime = localDateParamToUtc(startDate, timezone);
+    const endParts = parseLocalDateParts(endDate);
+    const endExclusiveDateTime = new Date(
+      new TZDate(
+        endParts.year,
+        endParts.monthIndex,
+        endParts.day + 1,
+        timezone
+      ).getTime()
+    );
+
+    return {
+      startDateTime,
+      endDateTime: new Date(endExclusiveDateTime.getTime() - 1),
+    };
+  }
+
+  return {
+    startDateTime: new Date(`${startDate}T00:00:00.000Z`),
+    endDateTime: new Date(`${endDate}T23:59:59.999Z`),
+  };
 }
 
 function getDaysInUtcMonth(date: Date): number {
@@ -330,7 +383,7 @@ export async function DELETE(
 
     // Parse parameters
     const startDate = searchParams.get("startDate");
-    const endDate = searchParams.get("endDate") || startDate;
+    const endDateParam = searchParams.get("endDate");
     const applicationsParam = searchParams.get("applications");
 
     if (!startDate || !applicationsParam) {
@@ -340,11 +393,21 @@ export async function DELETE(
       );
     }
 
+    const endDate = endDateParam || startDate;
     const applications = applicationsParam.split(",");
 
-    // Parse dates
-    const startDateTime = new Date(`${startDate}T00:00:00.000Z`);
-    const endDateTime = new Date(`${endDate}T23:59:59.999Z`);
+    const userPrefs = await db.userPreferences.findUnique({
+      where: { userId },
+      select: { timezone: true },
+    });
+    const timezone = userPrefs?.timezone || null;
+
+    // Parse dates as inclusive local calendar days when a timezone is known.
+    const { startDateTime, endDateTime } = getDeleteDateBounds(
+      startDate,
+      endDate,
+      timezone
+    );
 
     if (isNaN(startDateTime.getTime()) || isNaN(endDateTime.getTime())) {
       return NextResponse.json(
@@ -413,7 +476,8 @@ export async function DELETE(
         userId,
         applications,
         expandedAffectedPeriods,
-        tx
+        tx,
+        timezone
       );
 
       return {


### PR DESCRIPTION
## Summary
- treat delete-by-date values as inclusive local calendar days when a user timezone is stored
- pass the stored timezone into stats aggregate recalculation so daily buckets are rebuilt consistently with uploads
- add a focused check script for Boise winter/summer delete bounds

## Verification
- pnpm exec tsc --noEmit
- pnpm exec tsx scripts/check-delete-date-bounds.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now delete statistics across a date range instead of a single day. Deletion now respects user timezone settings when calculating accurate date boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Piebald-AI/splitrail-cloud/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->