### PR TITLE
Move stats delete helper out of route

### DIFF
--- a/scripts/check-delete-date-bounds.ts
+++ b/scripts/check-delete-date-bounds.ts
@@ -1,4 +1,4 @@
-import { getDeleteDateBounds } from "../src/app/api/user/[userId]/stats/route";
+import { getDeleteDateBounds } from "../src/app/api/user/[userId]/stats/delete-date-bounds";
 
 function assertEqual(actual: string, expected: string, label: string) {
   if (actual !== expected) {

--- a/src/app/api/user/[userId]/stats/delete-date-bounds.ts
+++ b/src/app/api/user/[userId]/stats/delete-date-bounds.ts
@@ -1,0 +1,52 @@
+import { TZDate } from "@date-fns/tz";
+
+function parseLocalDateParts(date: string): {
+  year: number;
+  monthIndex: number;
+  day: number;
+} {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) {
+    return { year: NaN, monthIndex: NaN, day: NaN };
+  }
+
+  return {
+    year: Number(match[1]),
+    monthIndex: Number(match[2]) - 1,
+    day: Number(match[3]),
+  };
+}
+
+function localDateParamToUtc(date: string, timezone: string): Date {
+  const { year, monthIndex, day } = parseLocalDateParts(date);
+  return new Date(new TZDate(year, monthIndex, day, timezone).getTime());
+}
+
+export function getDeleteDateBounds(
+  startDate: string,
+  endDate: string,
+  timezone: string | null
+): { startDateTime: Date; endDateTime: Date } {
+  if (timezone) {
+    const startDateTime = localDateParamToUtc(startDate, timezone);
+    const endParts = parseLocalDateParts(endDate);
+    const endExclusiveDateTime = new Date(
+      new TZDate(
+        endParts.year,
+        endParts.monthIndex,
+        endParts.day + 1,
+        timezone
+      ).getTime()
+    );
+
+    return {
+      startDateTime,
+      endDateTime: new Date(endExclusiveDateTime.getTime() - 1),
+    };
+  }
+
+  return {
+    startDateTime: new Date(`${startDate}T00:00:00.000Z`),
+    endDateTime: new Date(`${endDate}T23:59:59.999Z`),
+  };
+}

--- a/src/app/api/user/[userId]/stats/route.ts
+++ b/src/app/api/user/[userId]/stats/route.ts
@@ -1,4 +1,3 @@
-import { TZDate } from "@date-fns/tz";
 import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { auth } from "@/auth";
@@ -23,61 +22,12 @@ import {
   type TotalsAccumulator,
 } from "@/app/api/user/[userId]/stats/types";
 import { type StatsCollection } from "@/app/_stats/types";
+import { getDeleteDateBounds } from "./delete-date-bounds";
 
 function parseDailyStatsDay(day: DailyStatsRow["day"]): Date {
   return day instanceof Date ? day : new Date(day);
 }
 
-function parseLocalDateParts(date: string): {
-  year: number;
-  monthIndex: number;
-  day: number;
-} {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
-  if (!match) {
-    return { year: NaN, monthIndex: NaN, day: NaN };
-  }
-
-  return {
-    year: Number(match[1]),
-    monthIndex: Number(match[2]) - 1,
-    day: Number(match[3]),
-  };
-}
-
-function localDateParamToUtc(date: string, timezone: string): Date {
-  const { year, monthIndex, day } = parseLocalDateParts(date);
-  return new Date(new TZDate(year, monthIndex, day, timezone).getTime());
-}
-
-export function getDeleteDateBounds(
-  startDate: string,
-  endDate: string,
-  timezone: string | null
-): { startDateTime: Date; endDateTime: Date } {
-  if (timezone) {
-    const startDateTime = localDateParamToUtc(startDate, timezone);
-    const endParts = parseLocalDateParts(endDate);
-    const endExclusiveDateTime = new Date(
-      new TZDate(
-        endParts.year,
-        endParts.monthIndex,
-        endParts.day + 1,
-        timezone
-      ).getTime()
-    );
-
-    return {
-      startDateTime,
-      endDateTime: new Date(endExclusiveDateTime.getTime() - 1),
-    };
-  }
-
-  return {
-    startDateTime: new Date(`${startDate}T00:00:00.000Z`),
-    endDateTime: new Date(`${endDate}T23:59:59.999Z`),
-  };
-}
 
 function getDaysInUtcMonth(date: Date): number {
   return new Date(


### PR DESCRIPTION
## Summary
- move the exported delete date bounds helper out of the Next.js route module
- update the focused bounds check script to import the helper module directly
- keeps the timezone-aware delete behavior from #48 while satisfying Next route export rules

## Verification
- pnpm exec tsc --noEmit
- pnpm exec tsx scripts/check-delete-date-bounds.ts
- git diff --check