### PR TITLE
Add Copilot CLI application support

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -100,7 +100,12 @@ export default function Leaderboard() {
       usernameFilter,
     ],
     queryFn: async () => {
-      const applicationsParam = apps.join(",");
+      const hasAllApplicationsSelected =
+        apps.length === ALL_APPLICATIONS.length &&
+        ALL_APPLICATIONS.every((app) => apps.includes(app));
+      const applicationsParam = hasAllApplicationsSelected
+        ? "all"
+        : apps.join(",");
       const params = new URLSearchParams({
         applications: applicationsParam,
         sortBy: "cost",

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -396,15 +396,18 @@ export default function Leaderboard() {
             </TableBody>
           </Table>
         </div>
-        {data && data.privateUsersCount && data.privateUsersCount > 0 && !usernameFilter && (
-          <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-            <EyeOff className="size-4" />
-            <span>
-              + {data.privateUsersCount} private{" "}
-              {data.privateUsersCount === 1 ? "user" : "users"}
-            </span>
-          </div>
-        )}
+        {data &&
+          data.privateUsersCount &&
+          data.privateUsersCount > 0 &&
+          !usernameFilter && (
+            <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+              <EyeOff className="size-4" />
+              <span>
+                + {data.privateUsersCount} private{" "}
+                {data.privateUsersCount === 1 ? "user" : "users"}
+              </span>
+            </div>
+          )}
         <TablePagination table={table} />
       </div>
     </div>

--- a/src/lib/application-config.ts
+++ b/src/lib/application-config.ts
@@ -48,6 +48,10 @@ export const APPLICATION_CONFIG: Record<
     id: "copilot",
     label: "Copilot",
   },
+  copilot_cli: {
+    id: "copilot_cli",
+    label: "Copilot CLI",
+  },
   open_code: {
     id: "open_code",
     label: "OpenCode",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ export const Applications = [
   "kilo_code",
   "kilo_cli",
   "copilot",
+  "copilot_cli",
   "open_code",
   "pi_agent",
   "piebald",


### PR DESCRIPTION
## Why

Splitrail can receive usage from Copilot CLI, but the cloud application list does not currently recognize `copilot_cli`. Adding another supported application also changes the complete set used by the leaderboard filter; serializing every selected application individually would make the default all-applications request depend on that evolving list instead of using the API's existing `all` sentinel.

## What changed

- Add `copilot_cli` to the canonical supported application identifiers.
- Register the `Copilot CLI` label in the application configuration used by the UI.
- Detect when every supported application is selected on the leaderboard and send `applications=all`; preserve comma-separated application IDs for partial selections.

## Validation

- `pnpm type-check`
- `pnpm exec prettier --check src/app/leaderboard/page.tsx src/lib/application-config.ts src/types/index.ts`

Closes #52